### PR TITLE
Pass the affiliate ID when making the call to calculate the referral amount

### DIFF
--- a/EED_Affiliate_WP.module.php
+++ b/EED_Affiliate_WP.module.php
@@ -197,7 +197,7 @@ class EED_Affiliate_WP extends EED_Module
         }
 
         // valid affiliate so let's get creating the initial affiliate record.
-        $invoice_amount = $transaction->total() > 0 ? affwp_calc_referral_amount($transaction->total()) : 0;
+        $invoice_amount = $transaction->total() > 0 ? affwp_calc_referral_amount($transaction->total(), $awp->tracking->get_affiliate_id()) : 0;
 
         // get events on transaction so we can setup the description for this purchase.
         $registrations = $transaction->registrations();


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Reported here:
https://eventespresso.com/topic/affiliate-wp-ingtegration-commission-rate-not-tracking-correctly/

What happens is if the affiliate's Referral Rate is different than the default rate, then their earning will be the default rate. I tracked this down to `EED_Affiliate_WP::_maybe_initiate_affiliate_tracking` and noticed the affiliate ID wasn't passed. Adding the Affiliate ID fixes the issue for me. (This seems like kind of a weird gotcha)
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Set up an Affiliate in AffilateWP and 

- [x] set the Referral Rate to a different amount than the default referral rate
- [x] set the affiliate URL in your browser to test AffilateWP. For example if the affilate ID is 2, you add ?ref=1 to the URL
- [x] In the same browser sesssion, do a paid transaction  
- [x] Log into the site with the affilate account and go to the /affiliate-area/ page
- [x] Verify the referral and earning amounts are correct. (statistics view and referrals view)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
